### PR TITLE
各種エラー修正、未対応言語設定時もダイアログ表示するよう変更

### DIFF
--- a/ConfigManager.py
+++ b/ConfigManager.py
@@ -41,6 +41,26 @@ class ConfigManager(configparser.ConfigParser):
 			self.add_section(key)
 			return self.__getitem__(key)
 
+	def getstring(self,section,key,default="",selection=None,*, raw=False, vars=None,fallback=None):
+		if type(selection) not in (set,tuple,list):
+			raise TypeError("selection must be set, list or tuple")
+		ret=self.__getitem__(section)[key]
+		if ret=="":
+			if default=="":
+				self[section][key]=""
+				return ""
+			else:
+				self.log.debug("add default value.  at section "+section+", key "+key)
+				self[section][key]=default
+				ret=default
+				if selection==None:return ret
+
+		if ret not in selection:
+			self.log.debug("value "+ret+" not in selection.  at section "+section+", key "+key)
+			self[section][key]=default
+			ret=default
+		return ret
+
 	def getint(self,section,key,default=0,min=None,max=None):
 		if type(default)!=int:
 			raise ValueError("default value must be int")

--- a/app.py
+++ b/app.py
@@ -29,10 +29,6 @@ class Main(wx.App):
 		self.frozen=hasattr(sys,"frozen")
 		self.InitLogger()
 		self.LoadSettings()
-		if self.config["general"]["language"] == "":
-			# 翻訳
-			dialog("setting.ini not found. please select language.", "information")
-			self.langSelecter()
 		locale.setlocale(locale.LC_TIME,self.config["general"]["locale"])
 		self.SetTimeZone()
 		self.InitTranslation()
@@ -100,7 +96,16 @@ class Main(wx.App):
 
 	def InitTranslation(self):
 		"""翻訳を初期化する。"""
-		self.translator=gettext.translation("messages","locale", languages=[self.config["general"]["language"]], fallback=True)
+		lang=self.config.getstring("general","language","",constants.SUPPORTING_LANGUAGE)
+		if lang == "":
+			# 言語選択を表示
+			dialog("please select language.", "information")
+			langSelect = langDialog.langDialog()
+			langSelect.Initialize()
+			langSelect.Show()
+			self.config["general"]["language"] = langSelect.GetValue()
+			lang = langSelect.GetValue()
+		self.translator=gettext.translation("messages","locale", languages=[lang], fallback=True)
 		self.translator.install()
 
 	def GetFrozenStatus(self):
@@ -110,11 +115,6 @@ class Main(wx.App):
 	def say(self,s):
 		"""スクリーンリーダーでしゃべらせる。"""
 		self.speech.speak(s)
-
-	def langSelecter(self):
-		langSelect = langDialog.langDialog()
-		langSelect.Show(False)
-		self.config["general"]["language"] = langSelect.getValue()
 	def OnExit(self):
 		return wx.App.OnExit(self)
 

--- a/constants.py
+++ b/constants.py
@@ -10,6 +10,8 @@ APP_VERSION="0.5"
 APP_COPYRIGHT_YEAR="2020"
 APP_DEVELOPERS="Guredora"
 
+SUPPORTING_LANGUAGE=("ja-JP","en-US")
+
 #各種ファイル名
 SETTING_FILE_NAME="settings.ini"
 KEYMAP_FILE_NAME="keymap.ini"

--- a/views/baseDialog.py
+++ b/views/baseDialog.py
@@ -16,12 +16,15 @@ class BaseDialog(object):
 
 	def Initialize(self, parent,ttl,style=wx.DEFAULT_DIALOG_STYLE):
 		"""タイトルを指定して、ウィンドウを初期化し、親の中央に配置するように設定。"""
+		print("きた")
 		self.wnd=wx.Dialog(parent,-1, ttl,style= wx.CAPTION | wx.SYSTEM_MENU | wx.BORDER_DEFAULT | style)
+		print(self.wnd)
 		_winxptheme.SetWindowTheme(self.wnd.GetHandle(),"","")
 
 		self.wnd.Bind(wx.EVT_CLOSE,self.OnClose)
 
 		self.panel = wx.Panel(self.wnd,wx.ID_ANY)
+		print(self.panel)
 		self.sizer = wx.BoxSizer(wx.VERTICAL)
 		self.panel.SetSizer(self.sizer)
 

--- a/views/langDialog.py
+++ b/views/langDialog.py
@@ -15,7 +15,7 @@ class langDialog(BaseDialog):
 		self.identifier="language selecter"#このビューを表す文字列
 		self.log=getLogger("Soc%s" % (self.identifier))
 		self.log.debug("created")
-		super().Initialize(None,_("language settings"),0)
+		super().Initialize(None,"language settings",0)
 		self.InstallControls()
 		return True
 
@@ -23,7 +23,7 @@ class langDialog(BaseDialog):
 		"""いろんなwidgetを設置する。"""
 		self.creator=views.ViewCreator.ViewCreator(self.viewMode,self.panel,self.sizer,wx.VERTICAL,20)
 		#翻訳
-		self.langSelect = self.creator.combobox(_("select language"), constants.SUPPORTED_LANGUAGE, stat=0)
+		self.langSelect = self.creator.combobox("select language", constants.SUPPORTING_LANGUAGE, None, state=0)
 		self.ok = self.creator.okbutton("ok", None)
 
 	def Destroy(self, events = None):
@@ -31,4 +31,5 @@ class langDialog(BaseDialog):
 		self.wnd.Destroy()
 
 	def GetData(self):
-		return self.langSelect.GetSelectionString()
+		return self.langSelect.GetStringSelection()
+


### PR DESCRIPTION
・大きなエラー原因は、langDialog.Initialize()を呼び忘れていることでした。issueに投げる前に、よく確認してください。

・このダイアログは翻訳の初期化前に呼ばれるので、vuews.langDialog内では_()を使ってはいけません。

・iniファイルがあったとしても、無効な言語を指定される可能性はあります。そのような場合であっても問題にならないように、iniの読み込み時に対応している値をチェックできる機構をつけました。

・これに伴い、settings.iniがあったとしても言語選択が表示されることとなったため、メッセージを簡素化しています。ただ、あれだけだと辺な気もするので、何か考えておいてください。
