### PR TITLE
snapshotとtagged releasesでアセットの名前を変える

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ after_test:
   - "%PYTHON%\\python.exe tools\\build.py --appveyor"
 
 artifacts:
-  - path: SOC.zip
+  - path: SOC-*.zip
 
 deploy:
   - provider: GitHub
@@ -50,7 +50,7 @@ deploy:
     description: 'automatic build from master branch'
     auth_token:
       secure: UcoHc3nVwi+4feNv3QuMZy2qgZmTVElAD9iMr9UxcEUTA0PP2beWDMuiNhBoNYeA
-    artifact: SOC.zip                # upload all NuGet packages to release assets
+    artifact: SOC-snapshot.zip                # upload all NuGet packages to release assets
     draft: false
     prerelease: false
     on:
@@ -59,7 +59,7 @@ deploy:
     description: 'SOC official release'
     auth_token:
       secure: UcoHc3nVwi+4feNv3QuMZy2qgZmTVElAD9iMr9UxcEUTA0PP2beWDMuiNhBoNYeA
-    artifact: SOC.zip
+    artifact: SOC-$(APPVEYOR_REPO_TAG_NAME).zip
     draft: false
     prerelease: false
     on:

--- a/tools/build.py
+++ b/tools/build.py
@@ -17,6 +17,8 @@ if len(sys.argv)==2 and sys.argv[1]=="--appveyor":
 	appveyor=True
 
 print("Starting build (appveyor mode=%s)" % appveyor)
+build_filename=os.environ['APPVEYOR_REPO_TAG_NAME'] if 'APPVEYOR_REPO_TAG_NAME' in os.environ else 'snapshot'
+print("Will be built as %s" % build_filename)
 
 pyinstaller_path="pyinstaller.exe" if appveyor is False else "%PYTHON%\\Scripts\\pyinstaller.exe"
 hooks_path = os.path.join(PyInstaller.__path__[0], "hooks/")
@@ -39,5 +41,5 @@ shutil.copytree("tesseract-ocr\\", "dist\\SOC\\tesseract-ocr")
 shutil.copytree("poppler\\", "dist\\SOC\\poppler")
 shutil.copytree("locale\\","dist\\SOC\\locale", ignore=shutil.ignore_patterns("*.po", "*.pot", "*.po~"))
 print("Compressing into package...")
-shutil.make_archive('SOC','zip','dist')
+shutil.make_archive("SOC-%s" % (build_filename),'zip','dist')
 print("Done!")


### PR DESCRIPTION
appveyorでartifactを集めるときの指定をワイルドカードにし、ビルドスクリプトで環境変数を読んでファイル名を付け替えます。