### PR TITLE
JAWSの点字表示がフラッシュメッセージとして出力されるように修正

### DIFF
--- a/accessible_output2/outputs/jaws.py
+++ b/accessible_output2/outputs/jaws.py
@@ -20,7 +20,7 @@ class Jaws (Output):
 	def braille(self, text, **options):
 		# HACK: replace " with ', Jaws doesn't seem to understand escaping them with \
 		text = text.replace('"', "'")
-		self.object.RunFunction("BrailleString(\"%s\")" % text)
+		self.object.RunFunction("BrailleMessage(\"%s\")" % text)
 
 	def speak(self, text, interrupt=False):
 		self.object.SayString('      %s' % text, interrupt)


### PR DESCRIPTION
Accessible_output2に変更を加えました。
JAWSに点字を出力した際、従来は完全に表示内容が上書きされ、本来画面に表示されている内容を確認することができませんでした。
今回の変更により、出力した文字列が「フラッシュメッセージ」として表示されるようになります。
フラッシュメッセージはJAWS本体がメッセージを出力する際にも用いられている方法です。
具体的には、「msg」という文字列に続いてメッセージが表示され、
一定時間（ユーザが設定した時間）経過すると、自動的に元の表示に戻ります。
Accessible_output2の開発者がなぜこの方法を用いなかったかは不明ですが、この変更により、点字を利用している場合の使い勝手が向上するかと思います。