### PR TITLE
起動時にsettings.iniが正しく読み込まれていなかったのを修正

### DIFF
--- a/ConfigManager.py
+++ b/ConfigManager.py
@@ -21,7 +21,7 @@ class ConfigManager(configparser.ConfigParser):
 		if os.path.exists(fileName):
 			self.log.info("read configFile:"+fileName)
 			try:
-				with open(self.fileName,"r",encoding="utf-8") as f: return super().read(f)
+				return super().read(fileName, encoding='UTF-8')
 			except configparser.ParsingError:
 				self.log.warning("configFile parse failed.")
 				return []


### PR DESCRIPTION
configManagerのread関数の作りが他のソフトと違っており、それが不具合の原因のようでした。
