### PR TITLE
OAuthダイアログの構成を変更

### DIFF
--- a/views/authorizing.py
+++ b/views/authorizing.py
@@ -2,6 +2,9 @@
 # authorize dialog
 
 import wx
+import time
+import errorCodes
+import threading
 import globalVars
 import views.ViewCreator
 from logging import getLogger
@@ -11,28 +14,89 @@ class authorizeDialog(BaseDialog):
 	def __init__(self):
 		self.cancel = False
 		super().__init__("authorizingDialog")
+		self.web, self.pid = None, None
+		self.authThread = None
+		self.__isArrive = True
+		self.__authStarted = False
 
 	def Initialize(self):
 		self.log.debug("created")
-		super().Initialize(self.app.hMainView.hFrame,_("待機中..."),0)
+		super().Initialize(self.app.hMainView.hFrame,_("OAuth認証"))
 		self.InstallControls()
 		return True
 
 	def InstallControls(self):
 		"""いろんなwidgetを設置する。"""
 
-		self.creator=views.ViewCreator.ViewCreator(self.viewMode,self.panel,self.sizer,wx.VERTICAL,20)
-		self.creator.staticText(_("待機中..."),wx.ALIGN_CENTER,-1,wx.ALIGN_CENTER)
-		self.static = self.creator.staticText(_("認証大気中..."),wx.ALIGN_CENTER | wx.ST_ELLIPSIZE_MIDDLE,530,wx.ALIGN_CENTER)
-		self.bCancel=self.creator.button(_("キャンセル"), self.canceled,sizerFlag=wx.ALIGN_CENTER)
+		self.creator=views.ViewCreator.ViewCreator(self.viewMode,self.panel,self.sizer,wx.VERTICAL, 20)
+		self.static = self.creator.staticText(_("ブラウザを開いて認証手続きを行います。\r\nよろしいですか？"),wx.ALIGN_LEFT | wx.ST_ELLIPSIZE_MIDDLE,-1,wx.ALIGN_LEFT)
+		self.buttonCreator=views.ViewCreator.ViewCreator(self.viewMode,self.panel,self.sizer,wx.HORIZONTAL,20, style=wx.ALIGN_RIGHT)
+		self.bStart=self.buttonCreator.button(_("開始") + "(&S)", self.authorize)
+		self.bCancel=self.buttonCreator.button(_("キャンセル") + "(&C)", self.canceled)
+		self.wnd.SetDefaultItem(self.bStart)
 
+
+	def authorize(self,vevt):
+		if self.__authStarted:
+			self.finish()
+			return
+		self.__authStarted = True
+		self.static.SetLabel(_("認証を待機中..."))
+		self.bStart.Disable()
+
+
+		#認証プロセスの開始、認証用URL取得
+		url=globalVars.app.credentialManager.MakeFlow()
+		#ブラウザの表示
+		globalVars.app.say(_("ブラウザを開いています..."))
+		#webView=views.web.Dialog(url,"http://localhost")
+		#webView.Initialize()
+		#webView.Show()
+		self.web=wx.Process.Open("\"C:\\Program Files\\Internet Explorer\\iexplore.exe\" "+url)
+
+		self.authThread = threading.Thread(target=self.__auth)
+		self.authThread.start()
+
+	def __auth(self):
+		self.pid=self.web.GetPid()
+
+		#ユーザの認証待ち
+		status=errorCodes.WAITING_USER
+		evt=threading.Event()
+		while(status==errorCodes.WAITING_USER):
+			if not wx.Process.Exists(self.pid):
+				wx.CallAfter(self.end, errorCodes.CANCELED)
+				return
+			if status==errorCodes.WAITING_USER:
+				status=globalVars.app.credentialManager.getCredential()
+				if status == errorCodes.OK:
+					wx.CallAfter(self.authOk)
+					return
+			wx.YieldIfNeeded()
+			evt.wait(0.1)
+		wx.CallAfter(self.end, errorCodes.GOOGLE_ERROR)
+	
 	def canceled(self, events):
-		self.cancel = True
+		self.__isArrive = False
+		if self.web != None and self.pid != None and self.web.Exists(self.pid): wx.Process.Kill(self.pid,wx.SIGTERM) #修了要請
+		self.wnd.EndModal(errorCodes.CANCELED_BY_USER)
 
 
-	def end(self):
-		self.wnd.EndModal(wx.ID_OK)
+	def authOk(self):
+		globalVars.app.say(_("認証完了。ブラウザを閉じてください.."))
+		if self.web != None and self.pid != None and self.web.Exists(self.pid): wx.Process.Kill(self.pid,wx.SIGTERM) #修了要請
+		self.static.SetLabel(_("認証が完了しました。"))
+		self.bCancel.Disable()
+		self.bStart.SetLabel(_("完了") + "(&F)")
+		self.bStart.Enable()
+	
+	def end(self, code):
+		if self.web != None and self.pid != None and self.web.Exists(self.pid): wx.Process.Kill(self.pid,wx.SIGTERM) #修了要請
+		self.wnd.EndModal(code)
 
+	def finish(self):
+		self.wnd.EndModal(errorCodes.OK)
+	
 	def Destroy(self, events = None):
 		self.log.debug("destroy")
 		self.wnd.Destroy()

--- a/views/authorizing.py
+++ b/views/authorizing.py
@@ -12,7 +12,6 @@ from views.baseDialog import *
 
 class authorizeDialog(BaseDialog):
 	def __init__(self):
-		self.cancel = False
 		super().__init__("authorizingDialog")
 		self.web, self.pid = None, None
 		self.authThread = None
@@ -64,6 +63,7 @@ class authorizeDialog(BaseDialog):
 		status=errorCodes.WAITING_USER
 		evt=threading.Event()
 		while(status==errorCodes.WAITING_USER):
+			if self.__isArrive: return
 			if not wx.Process.Exists(self.pid):
 				wx.CallAfter(self.end, errorCodes.CANCELED)
 				return
@@ -96,10 +96,3 @@ class authorizeDialog(BaseDialog):
 
 	def finish(self):
 		self.wnd.EndModal(errorCodes.OK)
-	
-	def Destroy(self, events = None):
-		self.log.debug("destroy")
-		self.wnd.Destroy()
-
-	#def GetData(self):
-		return None

--- a/views/authorizing.py
+++ b/views/authorizing.py
@@ -63,7 +63,7 @@ class authorizeDialog(BaseDialog):
 		status=errorCodes.WAITING_USER
 		evt=threading.Event()
 		while(status==errorCodes.WAITING_USER):
-			if self.__isArrive: return
+			if not self.__isArrive: return
 			if not wx.Process.Exists(self.pid):
 				wx.CallAfter(self.end, errorCodes.CANCELED)
 				return

--- a/views/main.py
+++ b/views/main.py
@@ -233,48 +233,13 @@ class Events(BaseEvents):
 			self.parent.app.addFileList(pathList)
 			return
 		if selected==menuItemsStore.getRef("GOOGLE"):
-			#確認ダイアログ表示
-			result = qDialog(_("ブラウザを開き、認証を開始します。よろしいですか？"),_("確認"))
-			if result == wx.ID_NO:
-				return
-
-			#認証プロセスの開始、認証用URL取得
-			url=self.parent.app.credentialManager.MakeFlow()
-
 			authorizeDialog = authorizing.authorizeDialog()
 			authorizeDialog.Initialize()
-			authorizeDialog.Show(False)
-			#ブラウザの表示
-			self.parent.app.say(_("ブラウザを開いています..."))
+			status = authorizeDialog.Show()
 
-			#webView=views.web.Dialog(url,"http://localhost")
-			#webView.Initialize()
-			#webView.Show()
-			web=wx.Process.Open("\"C:\\Program Files\\Internet Explorer\\iexplore.exe\" "+url)
-
-			pid=web.GetPid()
-
-			#ユーザの認証待ち
-			status=errorCodes.WAITING_USER
-			evt=threading.Event()
-			while(status==errorCodes.WAITING_USER):
-				if not wx.Process.Exists(pid):
-					status=errorCodes.CANCELED
-				if authorizeDialog.cancel:
-					status = errorCodes.CANCELED_BY_USER
-				if status==errorCodes.WAITING_USER:
-					status=self.parent.app.credentialManager.getCredential()
-				wx.YieldIfNeeded()
-				evt.wait(0.3)
-			authorizeDialog.Destroy()
 			if status==errorCodes.OK:
-				if web.Exists(pid):
-					wx.Process.Kill(pid,wx.SIGTERM)		#修了要請
-				dialog(_("認証が完了しました"),_("認証結果"))
 				self.parent.menu.hMenuBar.Enable(menuItemsStore.getRef("GOOGLE"), False)
 			elif status == errorCodes.CANCELED_BY_USER:
-				if web.Exists(pid):
-					wx.Process.Kill(pid,wx.SIGTERM)		#修了要請
 				dialog(_("キャンセルしました。"))
 			elif status==errorCodes.IO_ERROR:
 				dialog(_("認証に成功しましたが、ファイルの保存に失敗しました。ディレクトリのアクセス権限などを確認してください。"),_("認証結果"))


### PR DESCRIPTION
OAuthダイアログの構成を変更しました。
NVDAの不安定動作が解消されています。
また、認証完了の通知をAO2出力とダイアログの更新としました。
これにより、ブラウザの閉じ忘れを抑制できると思われます。
